### PR TITLE
Slightly tweak the API

### DIFF
--- a/src/QuerySQLite.jl
+++ b/src/QuerySQLite.jl
@@ -19,6 +19,8 @@ sqlite3_column_type, sqlite3_step, sqlitevalue, Stmt, tables
 using TableShowUtils: printdataresource, printHTMLtable, printtable
 import TableTraits: isiterabletable
 
+export Database
+
 include("utilities.jl")
 include("source.jl")
 include("iterate.jl")

--- a/src/library.jl
+++ b/src/library.jl
@@ -27,7 +27,7 @@
 function get_column(source_row, column_name)
     SourceCode(source_row.source, Expr(:call, getproperty, source_row, column_name))
 end
-function model_row_dispatch(::typeof(getproperty), source_tables::SourceTables, table_name; other = false, options...)
+function model_row_dispatch(::typeof(getproperty), source_tables::Database, table_name; other = false, options...)
     source = get_source(source_tables)
     column_names = get_column_names(source, table_name)
     NamedTuple{column_names}(partial_map(
@@ -40,7 +40,7 @@ function model_row_dispatch(::typeof(getproperty), source_tables::SourceTables, 
         column_names
     ))
 end
-function translate_dispatch(::typeof(getproperty), source_tables::SourceTables, table_name; other = false, options...)
+function translate_dispatch(::typeof(getproperty), source_tables::Database, table_name; other = false, options...)
     if other
         translate(table_name)
     else

--- a/src/source.jl
+++ b/src/source.jl
@@ -25,18 +25,21 @@ export get_column_names
 
 
 """
-    struct SourceTables{Source}
+    struct Database{Source}
 
 `source` must support [`get_table_names`](@ref) and [`get_column_names`](@ref).
 """
-struct SourceTables{Source}
+struct Database{Source}
     source::Source
 end
-export SourceTables5
 
-get_source(source_tables::SourceTables) = getfield(source_tables, :source)
+function Database(filename::AbstractString)
+    return Database(SQLite.DB(filename))
+end
 
-function getproperty(source_tables::SourceTables, table_name::Symbol)
+get_source(source_tables::Database) = getfield(source_tables, :source)
+
+function getproperty(source_tables::Database, table_name::Symbol)
     SourceCode(get_source(source_tables),
         Expr(:call, getproperty, source_tables, table_name)
     )

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,11 +1,12 @@
 using Query
 using Test
-using QuerySQLite: SourceTables
-using SQLite: DB
+using QuerySQLite
+import SQLite
 using QueryTables
 
 filename = joinpath(@__DIR__, "Chinook_Sqlite.sqlite")
-database = SourceTables(DB(filename))
+database = Database(filename)
+database2 = Database(SQLite.DB(filename))
 
 @testset "QuerySQLite" begin
 
@@ -15,7 +16,7 @@ database = SourceTables(DB(filename))
     first |>
     propertynames == (:TrackId, :Name, :Composer, :UnitPrice)
 
-@test (database.Customer |>
+@test (database2.Customer |>
     @map({_.City, _.Country}) |>
     @orderby(_.Country) |>
     DataTable).Country[1] == "Argentina"


### PR DESCRIPTION
Do you think this makes sense?

I mostly care about the final API, i.e. I think it would be good if both
```julia
db = Database(filename)
```
and
```julia
db = Database(SQLite.DB(filename))
```
worked.

I think `SourceTables` is too opaque of a name for end users.