### PR TITLE
Enable doc deployment

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,8 +1,5 @@
 using Documenter: deploydocs, makedocs
-using Pkg: develop, instantiate, PackageSpec
 using QuerySQLite
 
-develop(PackageSpec(path=pwd()))
-instantiate()
 makedocs(sitename = "QuerySQLite.jl", modules = [QuerySQLite], doctest = false)
 deploydocs(repo = "github.com/queryverse/QuerySQLite.jl.git")


### PR DESCRIPTION
Fixes #11.

I'm using the GitHub Actions infrastructure for doc deployment, and package butler is setting everything up for us in queryverse packages. So all we need to do is merge this PR here, and then package butler will open another PR that enables auto doc deployment, and we're done.